### PR TITLE
Add support for extending the address space of a memory map

### DIFF
--- a/nmigen_soc/csr/wishbone.py
+++ b/nmigen_soc/csr/wishbone.py
@@ -3,6 +3,7 @@ from nmigen.utils import log2_int
 
 from . import Interface as CSRInterface
 from ..wishbone import Interface as WishboneInterface
+from ..memory import MemoryMap
 
 
 __all__ = ["WishboneCSRBridge"]
@@ -48,6 +49,9 @@ class WishboneCSRBridge(Elaboratable):
             data_width=data_width,
             granularity=csr_bus.data_width,
             name="wb")
+
+        self.wb_bus.memory_map = MemoryMap(addr_width=csr_bus.addr_width,
+                                           data_width=csr_bus.data_width)
 
         # Since granularity of the Wishbone interface matches the data width of the CSR bus,
         # no width conversion is performed, even if the Wishbone data width is greater.


### PR DESCRIPTION
This PR adds support for extending the address space of a `MemoryMap`, after it has been instantiated.

### Use case

Before this PR,  the `addr_width` parameter of a `csr.Multiplexer` would be the definitive address width of its underlying memory map.

This is inconvenient, because it forces the user to be aware of the size and address of each `csr.Element` that will be added to the multiplexer upfront.

```python3
from nmigen_soc import csr

mux = csr.Multiplexer(addr_width=2, data_width=8)
mux.add(csr.Element(8, "rw"))
mux.add(csr.Element(8, "rw"))
mux.add(csr.Element(8, "rw"))
```

This PR allows the address space covered by the `csr.Multiplexer` to be extended as resources are added to it.

```python3
mux = csr.Multiplexer(addr_width=1, data_width=8)
mux.add(csr.Element(8, "rw"), extend=True)
mux.add(csr.Element(8, "rw"), extend=True)
mux.add(csr.Element(8, "rw"), extend=True)

print(mux.bus.addr_width) # mux.bus.addr_width is now 2
```

The following primitives can support this use case:

- `csr.Multiplexer`
- `csr.Decoder`
- `wishbone.Decoder`

### Contents

- 7f27d90 adds support for address space extension to `nmigen_soc.memory`
- fa244cd ports `nmigen_soc.csr` and `nmigen_soc.wishbone` to the updated API