### PR TITLE
csr.wishbone: fix WishboneCSRBridge cycle counter.

### DIFF
--- a/nmigen_soc/csr/wishbone.py
+++ b/nmigen_soc/csr/wishbone.py
@@ -84,10 +84,11 @@ class WishboneCSRBridge(Elaboratable):
                 with m.Default():
                     m.d.sync += wb_bus.dat_r[segment(index)].eq(csr_bus.r_data)
                     m.d.sync += wb_bus.ack.eq(1)
-                    m.d.sync += cycle.eq(0)
 
         with m.Else():
             m.d.sync += wb_bus.ack.eq(0)
+
+        with m.If(wb_bus.ack):
             m.d.sync += cycle.eq(0)
 
         return m

--- a/nmigen_soc/test/test_csr_wishbone.py
+++ b/nmigen_soc/test/test_csr_wishbone.py
@@ -59,9 +59,10 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield dut.wb_bus.dat_w.eq(0x55)
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
             self.assertEqual((yield dut.wb_bus.ack), 1)
+            yield dut.wb_bus.stb.eq(0)
+            yield
             self.assertEqual((yield reg_1.r_count), 0)
             self.assertEqual((yield reg_1.w_count), 1)
             self.assertEqual((yield reg_1.data), 0x55)
@@ -71,9 +72,10 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield dut.wb_bus.dat_w.eq(0xaa)
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
+            yield dut.wb_bus.stb.eq(0)
             self.assertEqual((yield dut.wb_bus.ack), 1)
+            yield
             self.assertEqual((yield reg_2.r_count), 0)
             self.assertEqual((yield reg_2.w_count), 0)
             self.assertEqual((yield reg_2.data), 0)
@@ -83,9 +85,10 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield dut.wb_bus.dat_w.eq(0xbb)
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
             self.assertEqual((yield dut.wb_bus.ack), 1)
+            yield dut.wb_bus.stb.eq(0)
+            yield
             self.assertEqual((yield reg_2.r_count), 0)
             self.assertEqual((yield reg_2.w_count), 1)
             self.assertEqual((yield reg_2.data), 0xbbaa)
@@ -96,10 +99,11 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield dut.wb_bus.stb.eq(1)
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
             self.assertEqual((yield dut.wb_bus.ack), 1)
             self.assertEqual((yield dut.wb_bus.dat_r), 0x55)
+            yield dut.wb_bus.stb.eq(0)
+            yield
             self.assertEqual((yield reg_1.r_count), 1)
             self.assertEqual((yield reg_1.w_count), 1)
 
@@ -107,10 +111,11 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield dut.wb_bus.stb.eq(1)
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
             self.assertEqual((yield dut.wb_bus.ack), 1)
             self.assertEqual((yield dut.wb_bus.dat_r), 0xaa)
+            yield dut.wb_bus.stb.eq(0)
+            yield
             self.assertEqual((yield reg_2.r_count), 1)
             self.assertEqual((yield reg_2.w_count), 1)
 
@@ -120,10 +125,11 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield dut.wb_bus.stb.eq(1)
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
             self.assertEqual((yield dut.wb_bus.ack), 1)
             self.assertEqual((yield dut.wb_bus.dat_r), 0xbb)
+            yield dut.wb_bus.stb.eq(0)
+            yield
             self.assertEqual((yield reg_2.r_count), 1)
             self.assertEqual((yield reg_2.w_count), 1)
 
@@ -154,9 +160,10 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
             self.assertEqual((yield dut.wb_bus.ack), 1)
+            yield dut.wb_bus.stb.eq(0)
+            yield
             self.assertEqual((yield reg.r_count), 0)
             self.assertEqual((yield reg.w_count), 1)
             self.assertEqual((yield reg.data), 0x44332211)
@@ -170,9 +177,10 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
             self.assertEqual((yield dut.wb_bus.ack), 1)
+            yield dut.wb_bus.stb.eq(0)
+            yield
             self.assertEqual((yield reg.r_count), 0)
             self.assertEqual((yield reg.w_count), 1)
             self.assertEqual((yield reg.data), 0x44332211)
@@ -186,10 +194,11 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
             self.assertEqual((yield dut.wb_bus.ack), 1)
             self.assertEqual((yield dut.wb_bus.dat_r), 0x44332211)
+            yield dut.wb_bus.stb.eq(0)
+            yield
             self.assertEqual((yield reg.r_count), 1)
             self.assertEqual((yield reg.w_count), 1)
 
@@ -203,10 +212,11 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield
             yield
             yield
-            yield dut.wb_bus.stb.eq(0)
             yield
             self.assertEqual((yield dut.wb_bus.ack), 1)
             self.assertEqual((yield dut.wb_bus.dat_r), 0x00332200)
+            yield dut.wb_bus.stb.eq(0)
+            yield
             self.assertEqual((yield reg.r_count), 1)
             self.assertEqual((yield reg.w_count), 1)
 


### PR DESCRIPTION
Before this commit, a CSR could be read two times in a single WB transaction.

Repro:
```python3
from nmigen import *
from nmigen.back.pysim import *

from nmigen_soc import csr
from nmigen_soc.memory import MemoryMap
from nmigen_soc.csr.wishbone import WishboneCSRBridge


csr_bus = csr.Interface(addr_width=2, data_width=8)
csr_bus.memory_map = MemoryMap(addr_width=2, data_width=8)

dut = WishboneCSRBridge(csr_bus, data_width=32)

def process():
    yield dut.wb_bus.adr.eq(0x0)
    yield dut.wb_bus.cyc.eq(1)
    yield dut.wb_bus.stb.eq(1)
    yield dut.wb_bus.sel.eq(0b0001)
    yield
    while not (yield dut.wb_bus.ack):
        yield
    yield dut.wb_bus.cyc.eq(0)
    yield dut.wb_bus.stb.eq(0)

sim = Simulator(dut)
sim.add_clock(1e-6)
sim.add_sync_process(process)
with sim.write_vcd("repro.vcd"):
    sim.run()
```

![bad](https://user-images.githubusercontent.com/5796363/77440682-df097280-6de8-11ea-80de-a93c423b5f7b.jpg)

After this commit, only one read occurs:

![ok](https://user-images.githubusercontent.com/5796363/77444334-f85fee00-6deb-11ea-8c52-3abcd53d29cc.jpg)


