### PR TITLE
Test positional and keyword argument passing

### DIFF
--- a/nmigen_soc/test/test_csr_bus.py
+++ b/nmigen_soc/test/test_csr_bus.py
@@ -58,7 +58,7 @@ class ElementTestCase(unittest.TestCase):
     def test_access_wrong(self):
         with self.assertRaisesRegex(ValueError,
                 r"Access mode must be one of \"r\", \"w\", or \"rw\", not 'wo'"):
-            Element(1, "wo")
+            Element(width=1, access="wo")
 
 
 class InterfaceTestCase(unittest.TestCase):
@@ -154,7 +154,7 @@ class MultiplexerTestCase(unittest.TestCase):
     def test_add_wrong(self):
         with self.assertRaisesRegex(TypeError,
                 r"Element must be an instance of csr\.Element, not 'foo'"):
-            self.dut.add("foo")
+            self.dut.add(element="foo")
 
     def test_align_to(self):
         self.assertEqual(self.dut.add(Element(8, "rw")),
@@ -266,7 +266,7 @@ class MultiplexerAlignedTestCase(unittest.TestCase):
     def test_under_align_to(self):
         self.assertEqual(self.dut.add(Element(8, "rw")),
                          (0, 4))
-        self.assertEqual(self.dut.align_to(1), 4)
+        self.assertEqual(self.dut.align_to(alignment=1), 4)
         self.assertEqual(self.dut.add(Element(8, "rw")),
                          (4, 8))
 
@@ -315,6 +315,7 @@ class DecoderTestCase(unittest.TestCase):
         self.assertEqual(self.dut.add(sub_1), (0, 0x400, 1))
 
         self.assertEqual(self.dut.align_to(12), 0x1000)
+        self.assertEqual(self.dut.align_to(alignment=12), 0x1000)
 
         sub_2 = Interface(addr_width=10, data_width=8)
         sub_2.memory_map = MemoryMap(addr_width=10, data_width=8)
@@ -329,7 +330,7 @@ class DecoderTestCase(unittest.TestCase):
     def test_add_wrong_sub_bus(self):
         with self.assertRaisesRegex(TypeError,
                 r"Subordinate bus must be an instance of csr\.Interface, not 1"):
-            self.dut.add(1)
+            self.dut.add(sub_bus=1)
 
     def test_add_wrong_data_width(self):
         mux = Multiplexer(addr_width=10, data_width=16)

--- a/nmigen_soc/test/test_csr_wishbone.py
+++ b/nmigen_soc/test/test_csr_wishbone.py
@@ -33,7 +33,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
     def test_wrong_csr_bus(self):
         with self.assertRaisesRegex(ValueError,
                 r"CSR bus must be an instance of CSRInterface, not 'foo'"):
-            WishboneCSRBridge(csr_bus="foo")
+            WishboneCSRBridge("foo")
 
     def test_wrong_csr_bus_data_width(self):
         with self.assertRaisesRegex(ValueError,

--- a/nmigen_soc/test/test_event.py
+++ b/nmigen_soc/test/test_event.py
@@ -58,7 +58,7 @@ class EventMapTestCase(unittest.TestCase):
         src_1 = Source()
         event_map = EventMap()
         event_map.add(src_0)
-        event_map.add(src_1)
+        event_map.add(src=src_1)
         self.assertTrue(src_0 in event_map._sources)
         self.assertTrue(src_1 in event_map._sources)
 
@@ -88,7 +88,7 @@ class EventMapTestCase(unittest.TestCase):
         event_map.add(src_0)
         event_map.add(src_1)
         self.assertEqual(event_map.index(src_0), 0)
-        self.assertEqual(event_map.index(src_1), 1)
+        self.assertEqual(event_map.index(src=src_1), 1)
 
     def test_index_add_twice(self):
         src = Source()
@@ -139,7 +139,7 @@ class MonitorTestCase(unittest.TestCase):
     def test_event_map_wrong(self):
         with self.assertRaisesRegex(TypeError,
                 r"Event map must be an instance of EventMap, not 'foo'"):
-            dut = Monitor("foo")
+            dut = Monitor(event_map="foo")
 
     def test_events(self):
         sub_0 = Source(trigger="level")

--- a/nmigen_soc/test/test_memory.py
+++ b/nmigen_soc/test/test_memory.py
@@ -80,7 +80,7 @@ class MemoryMapTestCase(unittest.TestCase):
     def test_add_resource(self):
         memory_map = MemoryMap(addr_width=16, data_width=8)
         self.assertEqual(memory_map.add_resource("a", size=1), (0, 1))
-        self.assertEqual(memory_map.add_resource("b", size=2), (1, 3))
+        self.assertEqual(memory_map.add_resource(resource="b", size=2), (1, 3))
 
     def test_add_resource_map_aligned(self):
         memory_map = MemoryMap(addr_width=16, data_width=8, alignment=1)
@@ -197,7 +197,7 @@ class MemoryMapTestCase(unittest.TestCase):
         memory_map = MemoryMap(addr_width=16, data_width=8)
         with self.assertRaisesRegex(TypeError,
                 r"Window must be a MemoryMap, not 'a'"):
-            memory_map.add_window("a")
+            memory_map.add_window(window="a")
 
     def test_add_window_wrong_wider(self):
         memory_map = MemoryMap(addr_width=16, data_width=8)
@@ -284,7 +284,7 @@ class MemoryMapTestCase(unittest.TestCase):
         memory_map = MemoryMap(addr_width=16, data_width=8)
         with self.assertRaisesRegex(ValueError,
                 r"Alignment must be a non-negative integer, not -1"):
-            memory_map.align_to(-1)
+            memory_map.align_to(alignment=-1)
 
 
 class MemoryMapDiscoveryTestCase(unittest.TestCase):
@@ -334,4 +334,4 @@ class MemoryMapDiscoveryTestCase(unittest.TestCase):
             self.assertEqual(self.root.decode_address(end - 1), res)
 
     def test_decode_address_missing(self):
-        self.assertIsNone(self.root.decode_address(0x00000100))
+        self.assertIsNone(self.root.decode_address(address=0x00000100))

--- a/nmigen_soc/test/test_wishbone_bus.py
+++ b/nmigen_soc/test/test_wishbone_bus.py
@@ -134,6 +134,7 @@ class DecoderTestCase(unittest.TestCase):
         sub_2.memory_map = MemoryMap(addr_width=16, data_width=16)
         self.assertEqual(self.dut.add(sub_1), (0x00000000, 0x00010000, 1))
         self.assertEqual(self.dut.align_to(18), 0x000040000)
+        self.assertEqual(self.dut.align_to(alignment=18), 0x000040000)
         self.assertEqual(self.dut.add(sub_2), (0x00040000, 0x00050000, 1))
 
     def test_add_extend(self):
@@ -145,7 +146,7 @@ class DecoderTestCase(unittest.TestCase):
     def test_add_wrong(self):
         with self.assertRaisesRegex(TypeError,
                 r"Subordinate bus must be an instance of wishbone\.Interface, not 'foo'"):
-            self.dut.add("foo")
+            self.dut.add(sub_bus="foo")
 
     def test_add_wrong_granularity(self):
         with self.assertRaisesRegex(ValueError,
@@ -381,7 +382,7 @@ class ArbiterTestCase(unittest.TestCase):
     def test_add_wrong(self):
         with self.assertRaisesRegex(TypeError,
                 r"Initiator bus must be an instance of wishbone\.Interface, not 'foo'"):
-            self.dut.add("foo")
+            self.dut.add(intr_bus="foo")
 
     def test_add_wrong_addr_width(self):
         with self.assertRaisesRegex(ValueError,


### PR DESCRIPTION
When functions support positional argument passing both passing the
argument by position and by keyword is part of the API. Using both call
methods in the unit tests for such arguments will detect possible future
backwards compatibility breakage.