### PR TITLE
Use 0 as default for lock on subordinate bus

### DIFF
--- a/nmigen_soc/test/test_wishbone_bus.py
+++ b/nmigen_soc/test/test_wishbone_bus.py
@@ -438,7 +438,7 @@ class ArbiterSimulationTestCase(unittest.TestCase):
             self.assertEqual((yield dut.bus.sel), 0b1111)
             self.assertEqual((yield dut.bus.we), 1)
             self.assertEqual((yield dut.bus.dat_w), 0x12345678)
-            self.assertEqual((yield dut.bus.lock), 1)
+            self.assertEqual((yield dut.bus.lock), 0)
             self.assertEqual((yield dut.bus.cti), CycleType.CLASSIC.value)
             self.assertEqual((yield dut.bus.bte), BurstTypeExt.LINEAR.value)
             self.assertEqual((yield intr_1.dat_r), 0xabcdef01)

--- a/nmigen_soc/wishbone/bus.py
+++ b/nmigen_soc/wishbone/bus.py
@@ -99,6 +99,9 @@ class Interface(Record):
         Optional. Corresponds to Wishbone signal ``STALL_I`` (initiator) or ``STALL_O`` (target).
     lock : Signal()
         Optional. Corresponds to Wishbone signal ``LOCK_O`` (initiator) or ``LOCK_I`` (target).
+        nmigen-soc Wishbone support assumes that initiators that don't want bus arbitration to happen in
+        between two transactions need to use ``lock`` feature to guarantee this. An initiator without
+        the ``lock`` feature may be arbitrated in between two transactions even if ``cyc`` is kept high.
     cti : Signal()
         Optional. Corresponds to Wishbone signal ``CTI_O`` (initiator) or ``CTI_I`` (target).
     bte : Signal()
@@ -414,7 +417,7 @@ class Arbiter(Elaboratable):
                     ]
                     m.d.comb += self.bus.cyc.eq(intr_bus.cyc)
                     if hasattr(self.bus, "lock"):
-                        m.d.comb += self.bus.lock.eq(getattr(intr_bus, "lock", 1))
+                        m.d.comb += self.bus.lock.eq(getattr(intr_bus, "lock", 0))
                     if hasattr(self.bus, "cti"):
                         m.d.comb += self.bus.cti.eq(getattr(intr_bus, "cti", CycleType.CLASSIC))
                     if hasattr(self.bus, "bte"):


### PR DESCRIPTION
Assume that bus may be arbitrated if lock feature is not present on
initiator. This assumption is added to the docstring.