### PR TITLE
Provide a naming mechanism for memory map resources and windows

### DIFF
--- a/nmigen_soc/csr/bus.py
+++ b/nmigen_soc/csr/bus.py
@@ -76,9 +76,6 @@ class Element(Record):
             ]
         super().__init__(layout, name=name, src_loc_at=1 + src_loc_at)
 
-    # FIXME: get rid of this
-    __hash__ = object.__hash__
-
 
 class Interface(Record):
     """CPU-side CSR interface.

--- a/nmigen_soc/csr/bus.py
+++ b/nmigen_soc/csr/bus.py
@@ -212,14 +212,17 @@ class Multiplexer(Elaboratable):
         Data width. See :class:`Interface`.
     alignment : log2 of int
         Register alignment. See :class:`..memory.MemoryMap`.
+    name : str
+        Window name. Optional.
 
     Attributes
     ----------
     bus : :class:`Interface`
         CSR bus providing access to registers.
     """
-    def __init__(self, *, addr_width, data_width, alignment=0):
-        self._map = MemoryMap(addr_width=addr_width, data_width=data_width, alignment=alignment)
+    def __init__(self, *, addr_width, data_width, alignment=0, name=None):
+        self._map = MemoryMap(addr_width=addr_width, data_width=data_width, alignment=alignment,
+                              name=name)
         self._bus = None
 
     @property
@@ -250,7 +253,7 @@ class Multiplexer(Elaboratable):
 
         size = (element.width + self._map.data_width - 1) // self._map.data_width
         return self._map.add_resource(element, size=size, addr=addr, alignment=alignment,
-                                      extend=extend)
+                                      extend=extend, name=element.name)
 
     def elaborate(self, platform):
         m = Module()
@@ -262,7 +265,7 @@ class Multiplexer(Elaboratable):
         # 2-AND or 2-OR gates.
         r_data_fanin = 0
 
-        for elem, (elem_start, elem_end) in self._map.resources():
+        for elem, _, (elem_start, elem_end) in self._map.resources():
             shadow = Signal(elem.width, name="{}__shadow".format(elem.name))
             if elem.access.readable():
                 shadow_en = Signal(elem_end - elem_start, name="{}__shadow_en".format(elem.name))
@@ -327,14 +330,17 @@ class Decoder(Elaboratable):
         Data width. See :class:`Interface`.
     alignment : log2 of int
         Window alignment. See :class:`..memory.MemoryMap`.
+    name : str
+        Window name. Optional.
 
     Attributes
     ----------
     bus : :class:`Interface`
         CSR bus providing access to subordinate buses.
     """
-    def __init__(self, *, addr_width, data_width, alignment=0):
-        self._map  = MemoryMap(addr_width=addr_width, data_width=data_width, alignment=alignment)
+    def __init__(self, *, addr_width, data_width, alignment=0, name=None):
+        self._map  = MemoryMap(addr_width=addr_width, data_width=data_width, alignment=alignment,
+                               name=name)
         self._bus  = None
         self._subs = dict()
 

--- a/nmigen_soc/csr/wishbone.py
+++ b/nmigen_soc/csr/wishbone.py
@@ -27,13 +27,15 @@ class WishboneCSRBridge(Elaboratable):
         CSR bus driven by the bridge.
     data_width : int or None
         Wishbone bus data width. If not specified, defaults to ``csr_bus.data_width``.
+    name : str
+        Window name. Optional.
 
     Attributes
     ----------
     wb_bus : :class:`..wishbone.Interface`
         Wishbone bus provided by the bridge.
     """
-    def __init__(self, csr_bus, *, data_width=None):
+    def __init__(self, csr_bus, *, data_width=None, name=None):
         if not isinstance(csr_bus, CSRInterface):
             raise ValueError("CSR bus must be an instance of CSRInterface, not {!r}"
                              .format(csr_bus))
@@ -50,12 +52,12 @@ class WishboneCSRBridge(Elaboratable):
             granularity=csr_bus.data_width,
             name="wb")
 
-        self.wb_bus.memory_map = MemoryMap(addr_width=csr_bus.addr_width,
-                                           data_width=csr_bus.data_width)
-
+        wb_map = MemoryMap(addr_width=csr_bus.addr_width, data_width=csr_bus.data_width,
+                           name=name)
         # Since granularity of the Wishbone interface matches the data width of the CSR bus,
         # no width conversion is performed, even if the Wishbone data width is greater.
-        self.wb_bus.memory_map.add_window(self.csr_bus.memory_map)
+        wb_map.add_window(self.csr_bus.memory_map)
+        self.wb_bus.memory_map = wb_map
 
     def elaborate(self, platform):
         csr_bus = self.csr_bus

--- a/nmigen_soc/test/test_csr_bus.py
+++ b/nmigen_soc/test/test_csr_bus.py
@@ -125,29 +125,30 @@ class MultiplexerTestCase(unittest.TestCase):
         self.dut = Multiplexer(addr_width=16, data_width=8)
 
     def test_add_4b(self):
-        self.assertEqual(self.dut.add(Element(4, "rw")),
-                         (0, 1))
+        elem_4b = Element(4, "rw")
+        self.assertEqual(self.dut.add(elem_4b), (0, 1))
 
     def test_add_8b(self):
-        self.assertEqual(self.dut.add(Element(8, "rw")),
-                         (0, 1))
+        elem_8b = Element(8, "rw")
+        self.assertEqual(self.dut.add(elem_8b), (0, 1))
 
     def test_add_12b(self):
-        self.assertEqual(self.dut.add(Element(12, "rw")),
-                         (0, 2))
+        elem_12b = Element(12, "rw")
+        self.assertEqual(self.dut.add(elem_12b), (0, 2))
 
     def test_add_16b(self):
-        self.assertEqual(self.dut.add(Element(16, "rw")),
-                         (0, 2))
+        elem_16b = Element(16, "rw")
+        self.assertEqual(self.dut.add(elem_16b), (0, 2))
 
     def test_add_two(self):
-        self.assertEqual(self.dut.add(Element(16, "rw")),
-                         (0, 2))
-        self.assertEqual(self.dut.add(Element(8, "rw")),
-                         (2, 3))
+        elem_8b  = Element( 8, "rw")
+        elem_16b = Element(16, "rw")
+        self.assertEqual(self.dut.add(elem_16b), (0, 2))
+        self.assertEqual(self.dut.add(elem_8b),  (2, 3))
 
     def test_add_extend(self):
-        self.assertEqual(self.dut.add(Element(8, "rw"), addr=0x10000, extend=True),
+        elem_8b  = Element(8, "rw")
+        self.assertEqual(self.dut.add(elem_8b, addr=0x10000, extend=True),
                          (0x10000, 0x10001))
         self.assertEqual(self.dut.bus.addr_width, 17)
 
@@ -157,27 +158,28 @@ class MultiplexerTestCase(unittest.TestCase):
             self.dut.add(element="foo")
 
     def test_align_to(self):
-        self.assertEqual(self.dut.add(Element(8, "rw")),
-                         (0, 1))
+        elem_0  = Element( 8, "rw")
+        elem_1  = Element( 8, "rw")
+        self.assertEqual(self.dut.add(elem_0), (0, 1))
         self.assertEqual(self.dut.align_to(2), 4)
-        self.assertEqual(self.dut.add(Element(8, "rw")),
-                         (4, 5))
+        self.assertEqual(self.dut.add(elem_1), (4, 5))
 
     def test_add_wrong_out_of_bounds(self):
+        elem = Element(8, "rw")
         with self.assertRaisesRegex(ValueError,
                 r"Address range 0x10000\.\.0x10001 out of bounds for memory map spanning "
                 r"range 0x0\.\.0x10000 \(16 address bits\)"):
-            self.dut.add(Element(8, "rw"), addr=0x10000)
+            self.dut.add(elem, addr=0x10000)
 
     def test_sim(self):
-        bus = self.dut.bus
-
         elem_4_r = Element(4, "r")
         self.dut.add(elem_4_r)
         elem_8_w = Element(8, "w")
         self.dut.add(elem_8_w)
         elem_16_rw = Element(16, "rw")
         self.dut.add(elem_16_rw)
+
+        bus = self.dut.bus
 
         def sim_test():
             yield elem_4_r.r_data.eq(0xa)
@@ -252,30 +254,30 @@ class MultiplexerAlignedTestCase(unittest.TestCase):
         self.dut = Multiplexer(addr_width=16, data_width=8, alignment=2)
 
     def test_add_two(self):
-        self.assertEqual(self.dut.add(Element(8, "rw")),
-                         (0, 4))
-        self.assertEqual(self.dut.add(Element(16, "rw")),
-                         (4, 8))
+        elem_0 = Element( 8, "rw")
+        elem_1 = Element(16, "rw")
+        self.assertEqual(self.dut.add(elem_0), (0, 4))
+        self.assertEqual(self.dut.add(elem_1), (4, 8))
 
     def test_over_align_to(self):
-        self.assertEqual(self.dut.add(Element(8, "rw")),
-                         (0, 4))
+        elem_0 = Element(8, "rw")
+        elem_1 = Element(8, "rw")
+        self.assertEqual(self.dut.add(elem_0), (0, 4))
         self.assertEqual(self.dut.align_to(3), 8)
-        self.assertEqual(self.dut.add(Element(8, "rw")),
-                         (8, 12))
+        self.assertEqual(self.dut.add(elem_1), (8, 12))
 
     def test_under_align_to(self):
-        self.assertEqual(self.dut.add(Element(8, "rw")),
-                         (0, 4))
+        elem_0 = Element(8, "rw")
+        elem_1 = Element(8, "rw")
+        self.assertEqual(self.dut.add(elem_0), (0, 4))
         self.assertEqual(self.dut.align_to(alignment=1), 4)
-        self.assertEqual(self.dut.add(Element(8, "rw")),
-                         (4, 8))
+        self.assertEqual(self.dut.add(elem_1), (4, 8))
 
     def test_sim(self):
-        bus = self.dut.bus
-
         elem_20_rw = Element(20, "rw")
         self.dut.add(elem_20_rw)
+
+        bus = self.dut.bus
 
         def sim_test():
             yield bus.w_stb.eq(1)
@@ -353,14 +355,14 @@ class DecoderTestCase(unittest.TestCase):
 
     def test_sim(self):
         mux_1  = Multiplexer(addr_width=10, data_width=8)
-        self.dut.add(mux_1.bus)
         elem_1 = Element(8, "rw")
         mux_1.add(elem_1)
+        self.dut.add(mux_1.bus)
 
         mux_2  = Multiplexer(addr_width=10, data_width=8)
-        self.dut.add(mux_2.bus)
         elem_2 = Element(8, "rw")
         mux_2.add(elem_2, addr=2)
+        self.dut.add(mux_2.bus)
 
         elem_1_addr, _, _ = self.dut.bus.memory_map.find_resource(elem_1)
         elem_2_addr, _, _ = self.dut.bus.memory_map.find_resource(elem_2)

--- a/nmigen_soc/test/test_csr_bus.py
+++ b/nmigen_soc/test/test_csr_bus.py
@@ -364,8 +364,10 @@ class DecoderTestCase(unittest.TestCase):
         mux_2.add(elem_2, addr=2)
         self.dut.add(mux_2.bus)
 
-        elem_1_addr, _, _ = self.dut.bus.memory_map.find_resource(elem_1)
-        elem_2_addr, _, _ = self.dut.bus.memory_map.find_resource(elem_2)
+        elem_1_info = self.dut.bus.memory_map.find_resource(elem_1)
+        elem_2_info = self.dut.bus.memory_map.find_resource(elem_2)
+        elem_1_addr = elem_1_info.start
+        elem_2_addr = elem_2_info.start
         self.assertEqual(elem_1_addr, 0x0000)
         self.assertEqual(elem_2_addr, 0x0402)
 

--- a/nmigen_soc/test/test_csr_event.py
+++ b/nmigen_soc/test/test_csr_event.py
@@ -67,8 +67,8 @@ class EventMonitorTestCase(unittest.TestCase):
         monitor.add(sub_1)
         resources = list(monitor.bus.memory_map.resources())
         self.assertEqual(len(resources), 2)
-        enable,  enable_range  = resources[0]
-        pending, pending_range = resources[1]
+        enable,  enable_name,  enable_range  = resources[0]
+        pending, pending_name, pending_range = resources[1]
         self.assertEqual(
             (enable.width, enable.access, enable_range),
             (2, Element.Access.RW, (0, 1))

--- a/nmigen_soc/test/test_csr_wishbone.py
+++ b/nmigen_soc/test/test_csr_wishbone.py
@@ -9,8 +9,8 @@ from ..csr.wishbone import *
 
 
 class MockRegister(Elaboratable):
-    def __init__(self, width):
-        self.element = csr.Element(width, "rw")
+    def __init__(self, width, name):
+        self.element = csr.Element(width, "rw", name=name)
         self.r_count = Signal(8)
         self.w_count = Signal(8)
         self.data    = Signal(width)
@@ -42,9 +42,9 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
 
     def test_narrow(self):
         mux   = csr.Multiplexer(addr_width=10, data_width=8)
-        reg_1 = MockRegister(8)
+        reg_1 = MockRegister(8, name="reg_1")
         mux.add(reg_1.element)
-        reg_2 = MockRegister(16)
+        reg_2 = MockRegister(16, name="reg_2")
         mux.add(reg_2.element)
         dut   = WishboneCSRBridge(mux.bus)
 
@@ -143,7 +143,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
 
     def test_wide(self):
         mux = csr.Multiplexer(addr_width=10, data_width=8)
-        reg = MockRegister(32)
+        reg = MockRegister(32, name="reg")
         mux.add(reg.element)
         dut = WishboneCSRBridge(mux.bus, data_width=32)
 

--- a/nmigen_soc/test/test_periph.py
+++ b/nmigen_soc/test/test_periph.py
@@ -105,8 +105,8 @@ class PeripheralInfoTestCase(unittest.TestCase):
         memory_map = MemoryMap(addr_width=1, data_width=8)
         info = PeripheralInfo(memory_map=memory_map)
         with self.assertRaisesRegex(ValueError,
-                r"Memory map has been frozen. Address width cannot be extended further"):
-            memory_map.add_resource("a", size=3, extend=True)
+                r"Memory map has been frozen. Cannot add resource 'a'"):
+            memory_map.add_resource("a", name="foo", size=3, extend=True)
 
     def test_memory_map_wrong(self):
         with self.assertRaisesRegex(TypeError,

--- a/nmigen_soc/wishbone/bus.py
+++ b/nmigen_soc/wishbone/bus.py
@@ -186,6 +186,8 @@ class Decoder(Elaboratable):
         Optional signal set. See :class:`Interface`.
     alignment : log2 of int
         Window alignment. See :class:`..memory.MemoryMap`
+    name : str
+        Window name. Optional.
 
     Attributes
     ----------
@@ -193,7 +195,7 @@ class Decoder(Elaboratable):
         CSR bus providing access to subordinate buses.
     """
     def __init__(self, *, addr_width, data_width, granularity=None, features=frozenset(),
-                 alignment=0):
+                 alignment=0, name=None):
         if granularity is None:
             granularity  = data_width
         _check_interface(addr_width, data_width, granularity, features)
@@ -205,7 +207,8 @@ class Decoder(Elaboratable):
 
         granularity_bits = log2_int(data_width // granularity)
         self._map        = MemoryMap(addr_width=max(1, addr_width + granularity_bits),
-                                     data_width=granularity, alignment=alignment)
+                                     data_width=granularity, alignment=alignment,
+                                     name=name)
         self._subs       = dict()
         self._bus        = None
 


### PR DESCRIPTION
Each memory map now has a namespace for its resources and windows. Names are mandatory for resources, but optional for windows.

The full name of a resource is a concatenation of its own name and the name of each *named* window behind which it is located.
For example, if a resource named ``"rx_stb"`` is located behind an anonymous window, itself located behind a window named ``"serial"``, then its name would be ``("serial", "rx_stb")`` from the top-level point of view, but only ``("rx_stb",)`` from the point of view of the anonymous window.

Fixes #20.