### PR TITLE
CSR: Export Wishbone bridge from nmigen_soc.csr

### DIFF
--- a/nmigen_soc/csr/__init__.py
+++ b/nmigen_soc/csr/__init__.py
@@ -1,2 +1,3 @@
 from .bus import *
 from .event import *
+from .wishbone import WishboneCSRBridge as WishboneBridge


### PR DESCRIPTION
Alternative could be to rename `csr.wishbone.WishboneCSRBridge` to `csr.wishbone.WishboneBridge` and do 
```python
    from .wishbone import *
```
in `csr.__init__.py`
