### PR TITLE
csr/bus: Take data width into account for register writes

### DIFF
--- a/nmigen_soc/csr/bus.py
+++ b/nmigen_soc/csr/bus.py
@@ -293,7 +293,9 @@ class Multiplexer(Elaboratable):
                             m.d.sync += shadow_en.eq(self.bus.r_stb << chunk_offset)
 
                         if elem.access.writable():
-                            if chunk_addr == elem_end - 1:
+                            # Write when chunk_addr matches the start address of a chunk
+                            # aligned to the data width of the bus.
+                            if chunk_addr == elem_end - (1 << (log2_int(self.bus.data_width) - 3)):
                                 # Delay by 1 cycle, avoiding combinatorial paths through
                                 # the CSR bus and into CSR registers.
                                 m.d.sync += elem.w_stb.eq(self.bus.w_stb)

--- a/nmigen_soc/test/test_csr_wishbone.py
+++ b/nmigen_soc/test/test_csr_wishbone.py
@@ -6,27 +6,7 @@ from nmigen.back.pysim import *
 
 from .. import csr
 from ..csr.wishbone import *
-
-
-class MockRegister(Elaboratable):
-    def __init__(self, width):
-        self.element = csr.Element(width, "rw")
-        self.r_count = Signal(8)
-        self.w_count = Signal(8)
-        self.data    = Signal(width)
-
-    def elaborate(self, platform):
-        m = Module()
-
-        with m.If(self.element.r_stb):
-            m.d.sync += self.r_count.eq(self.r_count + 1)
-        m.d.comb += self.element.r_data.eq(self.data)
-
-        with m.If(self.element.w_stb):
-            m.d.sync += self.w_count.eq(self.w_count + 1)
-            m.d.sync += self.data.eq(self.element.w_data)
-
-        return m
+from .utils import MockRegister
 
 
 class WishboneCSRBridgeTestCase(unittest.TestCase):
@@ -42,9 +22,9 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
 
     def test_narrow(self):
         mux   = csr.Multiplexer(addr_width=10, data_width=8)
-        reg_1 = MockRegister(8)
+        reg_1 = MockRegister("reg_1", 8)
         mux.add(reg_1.element)
-        reg_2 = MockRegister(16)
+        reg_2 = MockRegister("reg_2", 16)
         mux.add(reg_2.element)
         dut   = WishboneCSRBridge(mux.bus)
 
@@ -143,7 +123,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
 
     def test_wide(self):
         mux = csr.Multiplexer(addr_width=10, data_width=8)
-        reg = MockRegister(32)
+        reg = MockRegister("reg", 32)
         mux.add(reg.element)
         dut = WishboneCSRBridge(mux.bus, data_width=32)
 

--- a/nmigen_soc/test/utils.py
+++ b/nmigen_soc/test/utils.py
@@ -1,0 +1,22 @@
+from nmigen import *
+from .. import csr
+
+class MockRegister(Elaboratable):
+    def __init__(self, name, width):
+        self.element = csr.Element(width, "rw", name=name)
+        self.r_count = Signal(8)
+        self.w_count = Signal(8)
+        self.data    = Signal(width)
+
+    def elaborate(self, platform):
+        m = Module()
+
+        with m.If(self.element.r_stb):
+            m.d.sync += self.r_count.eq(self.r_count + 1)
+        m.d.comb += self.element.r_data.eq(self.data)
+
+        with m.If(self.element.w_stb):
+            m.d.sync += self.w_count.eq(self.w_count + 1)
+            m.d.sync += self.data.eq(self.element.w_data)
+
+        return m


### PR DESCRIPTION
When using csr.Multiplexer with a data width greater than 8, writes should be performed when chunk_addr is matched to the start of a chunk.

I came across this when using a 32 bit wide data bus for both CSR and wishbone. I added a test case to match what I was doing.