### PR TITLE
csr.wishbone: Only ack for 1 cycle

### DIFF
--- a/nmigen_soc/csr/wishbone.py
+++ b/nmigen_soc/csr/wishbone.py
@@ -85,10 +85,8 @@ class WishboneCSRBridge(Elaboratable):
                     m.d.sync += wb_bus.dat_r[segment(index)].eq(csr_bus.r_data)
                     m.d.sync += wb_bus.ack.eq(1)
 
-        with m.Else():
-            m.d.sync += wb_bus.ack.eq(0)
-
         with m.If(wb_bus.ack):
             m.d.sync += cycle.eq(0)
+            m.d.sync += wb_bus.ack.eq(0)
 
         return m

--- a/nmigen_soc/test/test_csr_wishbone.py
+++ b/nmigen_soc/test/test_csr_wishbone.py
@@ -63,6 +63,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             self.assertEqual((yield dut.wb_bus.ack), 1)
             yield dut.wb_bus.stb.eq(0)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg_1.r_count), 0)
             self.assertEqual((yield reg_1.w_count), 1)
             self.assertEqual((yield reg_1.data), 0x55)
@@ -76,6 +77,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             yield dut.wb_bus.stb.eq(0)
             self.assertEqual((yield dut.wb_bus.ack), 1)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg_2.r_count), 0)
             self.assertEqual((yield reg_2.w_count), 0)
             self.assertEqual((yield reg_2.data), 0)
@@ -89,6 +91,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             self.assertEqual((yield dut.wb_bus.ack), 1)
             yield dut.wb_bus.stb.eq(0)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg_2.r_count), 0)
             self.assertEqual((yield reg_2.w_count), 1)
             self.assertEqual((yield reg_2.data), 0xbbaa)
@@ -104,6 +107,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             self.assertEqual((yield dut.wb_bus.dat_r), 0x55)
             yield dut.wb_bus.stb.eq(0)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg_1.r_count), 1)
             self.assertEqual((yield reg_1.w_count), 1)
 
@@ -116,6 +120,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             self.assertEqual((yield dut.wb_bus.dat_r), 0xaa)
             yield dut.wb_bus.stb.eq(0)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg_2.r_count), 1)
             self.assertEqual((yield reg_2.w_count), 1)
 
@@ -130,6 +135,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             self.assertEqual((yield dut.wb_bus.dat_r), 0xbb)
             yield dut.wb_bus.stb.eq(0)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg_2.r_count), 1)
             self.assertEqual((yield reg_2.w_count), 1)
 
@@ -165,6 +171,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             self.assertEqual((yield dut.wb_bus.ack), 1)
             yield dut.wb_bus.stb.eq(0)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg.r_count), 0)
             self.assertEqual((yield reg.w_count), 1)
             self.assertEqual((yield reg.data), 0x44332211)
@@ -182,6 +189,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             self.assertEqual((yield dut.wb_bus.ack), 1)
             yield dut.wb_bus.stb.eq(0)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg.r_count), 0)
             self.assertEqual((yield reg.w_count), 1)
             self.assertEqual((yield reg.data), 0x44332211)
@@ -200,6 +208,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             self.assertEqual((yield dut.wb_bus.dat_r), 0x44332211)
             yield dut.wb_bus.stb.eq(0)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg.r_count), 1)
             self.assertEqual((yield reg.w_count), 1)
 
@@ -218,6 +227,7 @@ class WishboneCSRBridgeTestCase(unittest.TestCase):
             self.assertEqual((yield dut.wb_bus.dat_r), 0x00332200)
             yield dut.wb_bus.stb.eq(0)
             yield
+            self.assertEqual((yield dut.wb_bus.ack), 0)
             self.assertEqual((yield reg.r_count), 1)
             self.assertEqual((yield reg.w_count), 1)
 


### PR DESCRIPTION
Currently we ack for 2 cycles, even if in the second cycle stb and cyc
are not asserted. This could cause issues on a shared wishbone with
asynchronous cycle termination, because that ack would be interpreted
as completing the next transaction.

To avoid this just ack for 1 cycle only.